### PR TITLE
Style: Update black chess piece color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,11 +11,9 @@
 }
 
 .chess-piece-black {
-  color: #111827; /* gray-900 */
+  color: #111827; /* Tailwind gray-900 */
   text-shadow: 
-    2px 2px 4px rgba(255,255,255,0.6),
-    -1px -1px 2px rgba(255,255,255,0.4),
-    1px -1px 2px rgba(255,255,255,0.4),
-    -1px 1px 2px rgba(255,255,255,0.4);
-  filter: contrast(1.3) brightness(0.15);
+    0px 0px 3px rgba(255,255,255,0.5),
+    0px 0px 5px rgba(255,255,255,0.3);
+  filter: contrast(1.1);
 }


### PR DESCRIPTION
This commit modifies the styling for black chess pieces in `styles.css` to better align with a "standard Chessbase" appearance.

The changes include:
- Updating the `text-shadow` to be softer and more diffuse.
- Removing the previous `brightness` filter and applying a milder `contrast` filter. The base color (`#111827`) remains the same.

This should improve the visual clarity and contrast of the black pieces.